### PR TITLE
AndroidX and cordova-android 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This plugin do and only do add the Multidex to AndroidManifest.xml following rul
 
 It has been optimized to work with androidx libraries. 
 
-Other useful libraries for your cordova app:
-https://github.com/dpa99c/cordova-plugin-androidx
-https://github.com/dpa99c/cordova-plugin-androidx-adapter
+Other useful libraries for your cordova app:  
+
+- https://github.com/dpa99c/cordova-plugin-androidx
+- https://github.com/dpa99c/cordova-plugin-androidx-adapter

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Multidex plugins for cordova
 
 This plugin do and only do add the Multidex to AndroidManifest.xml following rules in: http://developer.android.com/tools/building/multidex.html
+
+It has been optimized to work with androidx libraries. 
+
+Other useful libraries for your cordova app:
+https://github.com/dpa99c/cordova-plugin-androidx
+https://github.com/dpa99c/cordova-plugin-androidx-adapter

--- a/build.gradle
+++ b/build.gradle
@@ -10,5 +10,5 @@ android {
 }
 
 dependencies {
-  compile 'com.android.support:multidex:1.0.0'
+    implementation 'androidx:multidex:2.0.1'
 }

--- a/updateMultidexManifest.js
+++ b/updateMultidexManifest.js
@@ -1,9 +1,9 @@
-module.exports = function(ctx) {
+module.exports = function (ctx) {
     var fs = ctx.requireCordovaModule('fs'),
         path = ctx.requireCordovaModule('path'),
         xml = ctx.requireCordovaModule('cordova-common').xmlHelpers;
 
-    var manifestPath = path.join(ctx.opts.projectRoot, 'platforms/android/AndroidManifest.xml');
+    var manifestPath = path.join(ctx.opts.projectRoot, 'platforms/android/app/src/main/AndroidManifest.xml');
     var doc = xml.parseElementtreeSync(manifestPath);
     if (doc.getroot().tag !== 'manifest') {
         throw new Error(manifestPath + ' has incorrect root node name (expected "manifest")');
@@ -12,8 +12,8 @@ module.exports = function(ctx) {
     //adds the tools namespace to the root node
     // doc.getroot().attrib['xmlns:tools'] = 'http://schemas.android.com/tools';
     //add tools:replace in the application node
-    doc.getroot().find('./application').attrib['android:name'] = 'android.support.multidex.MultiDexApplication';
+    doc.getroot().find('./application').attrib['android:name'] = 'androidx.multidex.MultiDexApplication';
 
     //write the manifest file
-    fs.writeFileSync(manifestPath, doc.write({indent: 4}), 'utf-8');
+    fs.writeFileSync(manifestPath, doc.write({ indent: 4 }), 'utf-8');
 };


### PR DESCRIPTION
For those of us who are still using this plugin with Corodva android 8, androidX and a minSdk < 21, you will get errors when launching your app like:

```
java.lang.ClassNotFoundException: Didn't find class android.support.multidex.MultiDexApplication" on path: [..]
```

You can also get `FileNotFound` errors because the plugin is looking int he wrong location for the manifest. 

Both these issues have been solved in this pull request.